### PR TITLE
Bump node to 16 as 12 is EOL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: One or more (private SSH) Deploy Keys. Note, keys must be ed25519; rsa is not supported. The target repository must be added as a comment to the key, e.g. like `ssh-keygen ... -C "git@github.com:guardian/repo.git"`.
     required: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Access private Guardian repos in a Github Action.",
   "main": "index.js",
   "scripts": {
-    "build": "esbuild index.ts --bundle --platform=node --target=node12 --outfile=index.js"
+    "build": "esbuild index.ts --bundle --platform=node --target=node16 --outfile=index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
An attempt to remove the pesky warning when using the this GHA in other CIs.
Also Node 12 is EOL...

I cannot test this as I don't have write access to the repo (hence the fork) but hoping that replacing all mentions of 'node12' with 'node16' will work out of the box.